### PR TITLE
Use Vec<Vec3> for Image::data

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -50,11 +50,8 @@ impl Camera {
     }
 
     pub fn get_ray(self, x: usize, y: usize) -> Ray {
-        let dyrand: f32 = random();
-        let dxrand: f32 = random();
-
-        let dx: f32 = (dyrand + x as f32) / self.width as f32;
-        let dy: f32 = (dxrand + y as f32) / self.height as f32;
+        let dx: f32 = (random::<f32>() + x as f32) / self.width as f32;
+        let dy: f32 = (random::<f32>() + y as f32) / self.height as f32;
 
         Ray::new(
             self.pos,

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,10 +15,12 @@ impl Image {
     }
 
     pub fn create_with_colour(width: usize, height: usize, default_colour: f32) -> Self {
+        let default_colour_rgb = Vec3::new(default_colour, default_colour, default_colour);
+
         Image {
             width,
             height,
-            data: vec![default_colour; 3 * width * height],
+            data: vec![default_colour_rgb; width * height],
         }
     }
 
@@ -41,24 +43,27 @@ impl Image {
         file.write_all(header.as_bytes())
             .expect("Couldn't write header");
 
-        let to_be_written = self.data
+        let to_be_written = self
+            .data
             .iter()
-            .map(|e| ((e * 255.) as u8))
-            .collect::<Vec<_>>();
-
+            .copied()
+            .map(|e| e * 255.)
+            .flat_map(|e| {
+                [e.r(), e.g(), e.b()]
+                    .iter()
+                    .map(|x| *x as u8)
+                    .collect::<Vec<u8>>()
+            })
+            .collect::<Vec<u8>>();
         file.write_all(&to_be_written).expect("Couldn't write data");
     }
 
     pub fn save_as_bmp(&mut self, filepath: &str) {
         let mut file = File::create(filepath).expect("Couldn't open file");
-
-
     }
 
     pub fn set_pixel(&mut self, x: usize, y: usize, rgb: Vec3) {
         let idx = (x + y * self.width) * 3;
-        self.data[idx] = rgb.r();
-        self.data[idx + 1] = rgb.g();
-        self.data[idx + 2] = rgb.b();
+        self.data[idx] = rgb;
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -9,6 +9,28 @@ pub struct Image {
     data: Vec<f32>,
 }
 
+struct BitmapFileHeader {
+    bf_type: u16,
+    bf_size: u32,
+    bf_reserved1: u16,
+    bf_reserved2: u16,
+    bf_off_bits: u32
+}
+
+struct BitmapInfoHeader {
+    bi_size: u32,
+    bi_width: u32,
+    bi_height: u32,
+    bi_planes: u16,
+    bi_bit_count: u16,
+    bi_compression: u32,
+    bi_size_image: u32,
+    bi_x_px_meter: i32,
+    bi_y_px_meter: i32,
+    bi_clr_used: u32,
+    bi_clr_important: i32
+}
+
 impl Image {
     pub fn create(width: usize, height: usize) -> Self {
         Image::create_with_colour(width, height, 1.)

--- a/src/image.rs
+++ b/src/image.rs
@@ -41,11 +41,10 @@ impl Image {
         file.write_all(header.as_bytes())
             .expect("Couldn't write header");
 
-        let mut to_be_written = Vec::new();
-
-        self.data
+        let to_be_written = self.data
             .iter()
-            .for_each(|e| to_be_written.push((e * 255.) as u8));
+            .map(|e| ((e * 255.) as u8))
+            .collect::<Vec<_>>();
 
         file.write_all(&to_be_written).expect("Couldn't write data");
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -43,18 +43,14 @@ impl Image {
         file.write_all(header.as_bytes())
             .expect("Couldn't write header");
 
-        let to_be_written = self
+        let buff: &[u8] = &self
             .data
             .iter()
-            .map(|e| (*e) * 255.)
-            .flat_map(|e| {
-                [e.r(), e.g(), e.b()]
-                    .iter()
-                    .map(|x| *x as u8)
-                    .collect::<Vec<u8>>()
-            })
-            .collect::<Vec<u8>>();
-        file.write_all(&to_be_written).expect("Couldn't write data");
+            .map(|pixel_array| (*pixel_array) * 255.)
+            .flat_map(|pixel| [pixel.r() as u8, pixel.g() as u8, pixel.b() as u8])
+            .collect::<Vec<_>>();
+
+        file.write_all(buff).expect("Couldn't write data");
     }
 
     pub fn save_as_bmp(&mut self, filepath: &str) {

--- a/src/image.rs
+++ b/src/image.rs
@@ -6,29 +6,7 @@ use crate::vec3::Vec3;
 pub struct Image {
     width: usize,
     height: usize,
-    data: Vec<f32>,
-}
-
-struct BitmapFileHeader {
-    bf_type: u16,
-    bf_size: u32,
-    bf_reserved1: u16,
-    bf_reserved2: u16,
-    bf_off_bits: u32
-}
-
-struct BitmapInfoHeader {
-    bi_size: u32,
-    bi_width: u32,
-    bi_height: u32,
-    bi_planes: u16,
-    bi_bit_count: u16,
-    bi_compression: u32,
-    bi_size_image: u32,
-    bi_x_px_meter: i32,
-    bi_y_px_meter: i32,
-    bi_clr_used: u32,
-    bi_clr_important: i32
+    data: Vec<Vec3>,
 }
 
 impl Image {

--- a/src/image.rs
+++ b/src/image.rs
@@ -62,8 +62,8 @@ impl Image {
         let mut file = File::create(filepath).expect("Couldn't open file");
     }
 
+    #[inline]
     pub fn set_pixel(&mut self, x: usize, y: usize, rgb: Vec3) {
-        let idx = (x + y * self.width) * 3;
-        self.data[idx] = rgb;
+        self.data[x + y * self.width] = rgb;
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -46,8 +46,7 @@ impl Image {
         let to_be_written = self
             .data
             .iter()
-            .copied()
-            .map(|e| e * 255.)
+            .map(|e| (*e) * 255.)
             .flat_map(|e| {
                 [e.r(), e.g(), e.b()]
                     .iter()


### PR DESCRIPTION
Despite this being harder to convert into a format for ppm files it allows for a more generic and abstracted type to work with when using different file saving formats as the previous `Vec<f32>` was specific to the `.ppm` format.