### PR TITLE
Save as BMP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.ppm
+*.bmp

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -50,11 +50,8 @@ impl Camera {
     }
 
     pub fn get_ray(self, x: usize, y: usize) -> Ray {
-        let dyrand: f32 = random();
-        let dxrand: f32 = random();
-
-        let dx: f32 = (dyrand + x as f32) / self.width as f32;
-        let dy: f32 = (dxrand + y as f32) / self.height as f32;
+        let dx: f32 = (random::<f32>() + x as f32) / self.width as f32;
+        let dy: f32 = (random::<f32>() + y as f32) / self.height as f32;
 
         Ray::new(
             self.pos,

--- a/src/image.rs
+++ b/src/image.rs
@@ -64,23 +64,22 @@ impl Image {
             .rev()
             .flatten();
 
-        let mut buff: Vec<u8> = data
+        let buff: Vec<u8> = data
             .map(|pixel_array| pixel_array * 255.)
-            .flat_map(|pixel| [pixel.b() as u8, pixel.g() as u8, pixel.r() as u8])
-            .collect();
-
-        let padding_multiplyer = self.width % 4;
-
-        if padding_multiplyer != 0 {
-            (1..=self.height)
-                .map(|y| y * 3 * self.width)
-                .rev()
-                .for_each(|i| {
-                    for _ in 0..padding_multiplyer {
-                        buff.insert(i, 00)
+            .enumerate()
+            .flat_map(|pixel| {
+                if pixel.0 % self.width == self.width - 1 {
+                    let mut result = vec![pixel.1.b() as u8, pixel.1.g() as u8, pixel.1.r() as u8];
+                    for _ in 0..(self.width % 4) {
+                        result.push(0);
                     }
-                });
-        }
+
+                    result
+                } else {
+                    vec![pixel.1.b() as u8, pixel.1.g() as u8, pixel.1.r() as u8]
+                }
+            })
+            .collect();
 
         let mut info_header: [u8; 40] = [
             0x28, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00,

--- a/src/image.rs
+++ b/src/image.rs
@@ -56,18 +56,16 @@ impl Image {
     pub fn save_as_bmp(&mut self, filepath: &str) {
         let mut file = File::create(filepath).expect("Couldn't open file");
 
-        let data: Vec<Vec3> = (0..self.height)
+        let data = (0..self.height)
             .map(|y| {
                 let offset = y * self.width;
                 self.data[offset..offset + self.width].to_vec()
             })
             .rev()
-            .flatten()
-            .collect();
+            .flatten();
 
         let mut buff: Vec<u8> = data
-            .iter()
-            .map(|pixel_array| (*pixel_array) * 255.)
+            .map(|pixel_array| pixel_array * 255.)
             .flat_map(|pixel| [pixel.b() as u8, pixel.g() as u8, pixel.r() as u8])
             .collect();
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,10 +15,12 @@ impl Image {
     }
 
     pub fn create_with_colour(width: usize, height: usize, default_colour: f32) -> Self {
+        let default_colour_rgb = Vec3::new(default_colour, default_colour, default_colour);
+
         Image {
             width,
             height,
-            data: vec![default_colour; 3 * width * height],
+            data: vec![default_colour_rgb; width * height],
         }
     }
 
@@ -41,24 +43,27 @@ impl Image {
         file.write_all(header.as_bytes())
             .expect("Couldn't write header");
 
-        let to_be_written = self.data
+        let to_be_written = self
+            .data
             .iter()
-            .map(|e| ((e * 255.) as u8))
-            .collect::<Vec<_>>();
-
+            .copied()
+            .map(|e| e * 255.)
+            .flat_map(|e| {
+                [e.r(), e.g(), e.b()]
+                    .iter()
+                    .map(|x| *x as u8)
+                    .collect::<Vec<u8>>()
+            })
+            .collect::<Vec<u8>>();
         file.write_all(&to_be_written).expect("Couldn't write data");
     }
 
     pub fn save_as_bmp(&mut self, filepath: &str) {
         let mut file = File::create(filepath).expect("Couldn't open file");
-
-
     }
 
     pub fn set_pixel(&mut self, x: usize, y: usize, rgb: Vec3) {
         let idx = (x + y * self.width) * 3;
-        self.data[idx] = rgb.r();
-        self.data[idx + 1] = rgb.g();
-        self.data[idx + 2] = rgb.b();
+        self.data[idx] = rgb;
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -59,7 +59,7 @@ impl Image {
         let data: Vec<Vec3> = (0..self.height)
             .map(|y| {
                 let offset = y * self.width;
-                self.data[offset..offset+self.width].to_vec()
+                self.data[offset..offset + self.width].to_vec()
             })
             .rev()
             .flatten()
@@ -71,15 +71,23 @@ impl Image {
             .flat_map(|pixel| [pixel.b() as u8, pixel.g() as u8, pixel.r() as u8])
             .collect();
 
-        (1..=self.height)
-            .map(|y| y * 3 * self.width)
-            .rev()
-            .for_each(|i| {buff.insert(i, 00); buff.insert(i, 00)});
+        let padding_multiplyer = self.width % 4;
+
+        if padding_multiplyer != 0 {
+            (1..=self.height)
+                .map(|y| y * 3 * self.width)
+                .rev()
+                .for_each(|i| {
+                    for _ in 0..padding_multiplyer {
+                        buff.insert(i, 00)
+                    }
+                });
+        }
 
         let width: Vec<u8> = (self.width as u32).to_le_bytes().to_vec();
         let height: Vec<u8> = (self.height as u32).to_le_bytes().to_vec();
 
-        let buff_size = ((self.data.len()*4) as u32).to_le_bytes();
+        let buff_size = ((self.data.len() * 4) as u32).to_le_bytes();
 
         let mut info_header: Vec<u8> = vec![
             0x28, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00,

--- a/src/image.rs
+++ b/src/image.rs
@@ -68,9 +68,7 @@ impl Image {
             .flat_map(|pixel| {
                 if pixel.0 % self.width == self.width - 1 {
                     let mut result = vec![pixel.1.b() as u8, pixel.1.g() as u8, pixel.1.r() as u8];
-                    for _ in 0..(self.width % 4) {
-                        result.push(0);
-                    }
+                    result.extend(vec![0; self.width % 4]);
 
                     result
                 } else {
@@ -93,8 +91,7 @@ impl Image {
             0x42, 0x4D, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00,
         ];
 
-        let total_size: [u8; 4] = ((buff.len() + info_header.len() + 16) as u32)
-            .to_le_bytes();
+        let total_size: [u8; 4] = ((buff.len() + info_header.len() + 16) as u32).to_le_bytes();
 
         header[2..6].copy_from_slice(&total_size);
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -92,17 +92,16 @@ impl Image {
         info_header[8..12].copy_from_slice(&(self.height as u32).to_le_bytes());
         info_header[20..24].copy_from_slice(&(((self.data.len() * 4) as u32).to_le_bytes()));
 
-        let mut header: Vec<u8> = vec![
+        let mut header: [u8; 14] = [
             0x42, 0x4D, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00,
         ];
 
-        let total_size: Vec<u8> = ((buff.len() + info_header.len() + 16) as u32)
-            .to_le_bytes()
-            .to_vec();
+        let total_size: [u8; 4] = ((buff.len() + info_header.len() + 16) as u32)
+            .to_le_bytes();
 
-        header.splice(2..6, total_size);
+        header[2..6].copy_from_slice(&total_size);
 
-        let result: Vec<u8> = [header, info_header.to_vec(), buff]
+        let result: Vec<u8> = [header.to_vec(), info_header.to_vec(), buff]
             .iter()
             .flatten()
             .copied()

--- a/src/image.rs
+++ b/src/image.rs
@@ -9,6 +9,28 @@ pub struct Image {
     data: Vec<f32>,
 }
 
+struct BitmapFileHeader {
+    bf_type: u16,
+    bf_size: u32,
+    bf_reserved1: u16,
+    bf_reserved2: u16,
+    bf_off_bits: u32
+}
+
+struct BitmapInfoHeader {
+    bi_size: u32,
+    bi_width: u32,
+    bi_height: u32,
+    bi_planes: u16,
+    bi_bit_count: u16,
+    bi_compression: u32,
+    bi_size_image: u32,
+    bi_x_px_meter: i32,
+    bi_y_px_meter: i32,
+    bi_clr_used: u32,
+    bi_clr_important: i32
+}
+
 impl Image {
     pub fn create(width: usize, height: usize) -> Self {
         Image::create_with_colour(width, height, 1.)

--- a/src/image.rs
+++ b/src/image.rs
@@ -82,20 +82,15 @@ impl Image {
                 });
         }
 
-        let width: Vec<u8> = (self.width as u32).to_le_bytes().to_vec();
-        let height: Vec<u8> = (self.height as u32).to_le_bytes().to_vec();
-
-        let buff_size = ((self.data.len() * 4) as u32).to_le_bytes();
-
-        let mut info_header: Vec<u8> = vec![
+        let mut info_header: [u8; 40] = [
             0x28, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00,
             0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
-        info_header.splice(4..8, width);
-        info_header.splice(8..12, height);
-        info_header.splice(20..24, buff_size);
+        info_header[4..8].copy_from_slice(&(self.width as u32).to_le_bytes());
+        info_header[8..12].copy_from_slice(&(self.height as u32).to_le_bytes());
+        info_header[20..24].copy_from_slice(&(((self.data.len() * 4) as u32).to_le_bytes()));
 
         let mut header: Vec<u8> = vec![
             0x42, 0x4D, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00,
@@ -107,7 +102,7 @@ impl Image {
 
         header.splice(2..6, total_size);
 
-        let result: Vec<u8> = [header, info_header, buff]
+        let result: Vec<u8> = [header, info_header.to_vec(), buff]
             .iter()
             .flatten()
             .copied()

--- a/src/image.rs
+++ b/src/image.rs
@@ -27,7 +27,7 @@ impl Image {
     pub fn save(&mut self, filepath: &str) -> Result<(), &str> {
         if filepath.ends_with(".ppm") {
             self.save_as_ppm(filepath);
-        } else if filepath.ends_with(".bpm") {
+        } else if filepath.ends_with(".bmp") {
             self.save_as_bmp(filepath)
         } else {
             return Err("Unknown filetype");
@@ -55,6 +55,59 @@ impl Image {
 
     pub fn save_as_bmp(&mut self, filepath: &str) {
         let mut file = File::create(filepath).expect("Couldn't open file");
+
+        let data: Vec<Vec3> = (0..self.height)
+            .map(|y| {
+                let offset = y * self.width;
+                self.data[offset..offset+self.width].to_vec()
+            })
+            .rev()
+            .flatten()
+            .collect();
+
+        let mut buff: Vec<u8> = data
+            .iter()
+            .map(|pixel_array| (*pixel_array) * 255.)
+            .flat_map(|pixel| [pixel.b() as u8, pixel.g() as u8, pixel.r() as u8])
+            .collect();
+
+        (1..=self.height)
+            .map(|y| y * 3 * self.width)
+            .rev()
+            .for_each(|i| {buff.insert(i, 00); buff.insert(i, 00)});
+
+        let width: Vec<u8> = (self.width as u32).to_le_bytes().to_vec();
+        let height: Vec<u8> = (self.height as u32).to_le_bytes().to_vec();
+
+        let buff_size = ((self.data.len()*4) as u32).to_le_bytes();
+
+        let mut info_header: Vec<u8> = vec![
+            0x28, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01, 0x00,
+            0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        info_header.splice(4..8, width);
+        info_header.splice(8..12, height);
+        info_header.splice(20..24, buff_size);
+
+        let mut header: Vec<u8> = vec![
+            0x42, 0x4D, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00,
+        ];
+
+        let total_size: Vec<u8> = ((buff.len() + info_header.len() + 16) as u32)
+            .to_le_bytes()
+            .to_vec();
+
+        header.splice(2..6, total_size);
+
+        let mut result: Vec<u8> = Vec::new();
+
+        result.append(&mut header);
+        result.append(&mut info_header);
+        result.append(&mut buff);
+
+        file.write_all(&result).expect("Couldn't write data");
     }
 
     #[inline]

--- a/src/image.rs
+++ b/src/image.rs
@@ -41,11 +41,10 @@ impl Image {
         file.write_all(header.as_bytes())
             .expect("Couldn't write header");
 
-        let mut to_be_written = Vec::new();
-
-        self.data
+        let to_be_written = self.data
             .iter()
-            .for_each(|e| to_be_written.push((e * 255.) as u8));
+            .map(|e| ((e * 255.) as u8))
+            .collect::<Vec<_>>();
 
         file.write_all(&to_be_written).expect("Couldn't write data");
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -6,29 +6,7 @@ use crate::vec3::Vec3;
 pub struct Image {
     width: usize,
     height: usize,
-    data: Vec<f32>,
-}
-
-struct BitmapFileHeader {
-    bf_type: u16,
-    bf_size: u32,
-    bf_reserved1: u16,
-    bf_reserved2: u16,
-    bf_off_bits: u32
-}
-
-struct BitmapInfoHeader {
-    bi_size: u32,
-    bi_width: u32,
-    bi_height: u32,
-    bi_planes: u16,
-    bi_bit_count: u16,
-    bi_compression: u32,
-    bi_size_image: u32,
-    bi_x_px_meter: i32,
-    bi_y_px_meter: i32,
-    bi_clr_used: u32,
-    bi_clr_important: i32
+    data: Vec<Vec3>,
 }
 
 impl Image {

--- a/src/image.rs
+++ b/src/image.rs
@@ -62,8 +62,8 @@ impl Image {
         let mut file = File::create(filepath).expect("Couldn't open file");
     }
 
+    #[inline]
     pub fn set_pixel(&mut self, x: usize, y: usize, rgb: Vec3) {
-        let idx = (x + y * self.width) * 3;
-        self.data[idx] = rgb;
+        self.data[x + y * self.width] = rgb;
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -101,11 +101,10 @@ impl Image {
 
         header[2..6].copy_from_slice(&total_size);
 
-        let result: Vec<u8> = [header.to_vec(), info_header.to_vec(), buff]
-            .iter()
-            .flatten()
-            .copied()
-            .collect();
+        let mut result: Vec<u8> = vec![];
+        result.extend_from_slice(&header);
+        result.extend_from_slice(&info_header);
+        result.extend(buff);
 
         file.write_all(&result).expect("Couldn't write data");
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -109,11 +109,11 @@ impl Image {
 
         header.splice(2..6, total_size);
 
-        let mut result: Vec<u8> = Vec::new();
-
-        result.append(&mut header);
-        result.append(&mut info_header);
-        result.append(&mut buff);
+        let result: Vec<u8> = [header, info_header, buff]
+            .iter()
+            .flatten()
+            .copied()
+            .collect();
 
         file.write_all(&result).expect("Couldn't write data");
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -56,15 +56,13 @@ impl Image {
     pub fn save_as_bmp(&mut self, filepath: &str) {
         let mut file = File::create(filepath).expect("Couldn't open file");
 
-        let data = (0..self.height)
+        let buff: Vec<u8> = (0..self.height)
             .map(|y| {
                 let offset = y * self.width;
                 self.data[offset..offset + self.width].to_vec()
             })
             .rev()
-            .flatten();
-
-        let buff: Vec<u8> = data
+            .flatten()
             .map(|pixel_array| pixel_array * 255.)
             .enumerate()
             .flat_map(|pixel| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,5 +78,5 @@ fn main() {
         }
     }
 
-    img.save("test.ppm");
+    img.save("test.bmp");
 }


### PR DESCRIPTION
Using the information detailed [here](https://en.wikipedia.org/wiki/BMP_file_format) we can adjust the pixel data slightly to arrange it in a way that can be outputted as binary data into a BMP file with the `.bmp` file extension.